### PR TITLE
ci: add doc-automation workflow shell

### DIFF
--- a/.github/workflows/update-septic-docs-pr.yml
+++ b/.github/workflows/update-septic-docs-pr.yml
@@ -1,0 +1,13 @@
+name: "📚 Update SEPTIC docs"
+
+on: 
+  workflow_dispatch:
+  repository_dispatch:
+    types: [execute]
+
+jobs:
+  update_doc_pr:
+    name: "📚 Update PR"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4


### PR DESCRIPTION
Need a base workflow in main .github/workflows directory to enable development of a working workflow.

After this gets merged to main, I can continue with #382 