### PR TITLE
fix: bug in diagnostics for objects with no identifier

### DIFF
--- a/server/src/language-service/diagnosticsProvider.ts
+++ b/server/src/language-service/diagnosticsProvider.ts
@@ -826,6 +826,9 @@ function validateDuplicateIdentifiers(
     refProvider: SepticReferenceProvider,
     doc: ITextDocument
 ): Diagnostic[] {
+    if (!obj.identifier) {
+        return [];
+    }
     let validationFunction: RefValidationFunction;
     if (obj.isXvr()) {
         validationFunction = hasDuplicateReferenceXvr;
@@ -834,6 +837,7 @@ function validateDuplicateIdentifiers(
     } else {
         return [];
     }
+
     let validRef = refProvider.validateRef(
         obj.identifier!.name,
         validationFunction

--- a/server/src/test/diagnostics.test.ts
+++ b/server/src/test/diagnostics.test.ts
@@ -1241,6 +1241,26 @@ describe("Test validation of object references", () => {
         );
         expect(diagFilterd.length).to.equal(0);
     });
+    it("Expect no diagnostics for sopcxvr without identifier", () => {
+        const text = `
+            SopcEvr: 
+            
+            Evr: TestEvr
+		`;
+        const doc = new MockDocument(text);
+        const cnfg = parseSepticSync(doc.getText());
+        const objectInfo = metaInfoProvider.getObject("MvrList");
+        let diag = validateObjectReferences(
+            cnfg.objects[0],
+            doc,
+            cnfg,
+            objectInfo!
+        );
+        let diagFilterd = diag.filter(
+            (d) => d.code === DiagnosticCode.duplicate
+        );
+        expect(diagFilterd.length).to.equal(0);
+    });
 });
 
 describe("Test validation of object structure", () => {


### PR DESCRIPTION
Closes #571 