### PR TITLE
feat: add warning on case discrepancies in SCG YAML file paths (W701)

### DIFF
--- a/packages/extension/client/src/protocol.ts
+++ b/packages/extension/client/src/protocol.ts
@@ -83,6 +83,10 @@ export const fsReadFile = new RequestType<{ uri: string }, number[], unknown>(
     "septic/fs_readfile",
 );
 
+export const fsReadDir = new RequestType<{ uri: string }, string[], unknown>(
+    "septic/fs_readdir",
+);
+
 export const findYamlFiles = new RequestType<object, string[], unknown>(
     "septic/findYamlFiles",
 );

--- a/packages/extension/client/src/requests.ts
+++ b/packages/extension/client/src/requests.ts
@@ -9,30 +9,33 @@ import { getSearchPattern } from "./util";
 import { LanguageClient } from "vscode-languageclient/node";
 
 export function registerRequestHandlers(client: LanguageClient) {
-	client.onRequest(protocol.globFiles, async (params) => {
-		const parsedUri = vscode.Uri.parse(params.uri);
-		const folder = vscode.workspace.getWorkspaceFolder(parsedUri);
-		if (!folder) {
-			return [];
-		}
-		const pattern = getSearchPattern(folder.uri.path, parsedUri.path);
-		const files = await vscode.workspace.findFiles(pattern);
-		return files
-			.filter((f) => f.fsPath.includes(folder.uri.fsPath))
-			.map((f) => f.toString());
-	});
+    client.onRequest(protocol.globFiles, async (params) => {
+        const parsedUri = vscode.Uri.parse(params.uri);
+        const folder = vscode.workspace.getWorkspaceFolder(parsedUri);
+        if (!folder) {
+            return [];
+        }
+        const pattern = getSearchPattern(folder.uri.path, parsedUri.path);
+        const files = await vscode.workspace.findFiles(pattern);
+        return files
+            .filter((f) => f.fsPath.includes(folder.uri.fsPath))
+            .map((f) => f.toString());
+    });
 
-	client.onRequest(
-		protocol.fsReadFile,
-		async (e): Promise<number[]> => {
-			const uri = vscode.Uri.parse(e.uri);
-			return Array.from(await vscode.workspace.fs.readFile(uri));
-		}
-	);
+    client.onRequest(protocol.fsReadFile, async (e): Promise<number[]> => {
+        const uri = vscode.Uri.parse(e.uri);
+        return Array.from(await vscode.workspace.fs.readFile(uri));
+    });
 
-	client.onRequest(protocol.findYamlFiles, async () => {
-		return (await vscode.workspace.findFiles(`**/*.yaml`)).map((f) =>
-			f.toString()
-		);
-	});
+    client.onRequest(protocol.fsReadDir, async (e): Promise<string[]> => {
+        const uri = vscode.Uri.parse(e.uri);
+        const entries = await vscode.workspace.fs.readDirectory(uri);
+        return entries.map(([name]) => name);
+    });
+
+    client.onRequest(protocol.findYamlFiles, async () => {
+        return (await vscode.workspace.findFiles(`**/*.yaml`)).map((f) =>
+            f.toString(),
+        );
+    });
 }

--- a/packages/extension/server/src/protocol.ts
+++ b/packages/extension/server/src/protocol.ts
@@ -43,6 +43,10 @@ export const fsReadFile = new RequestType<{ uri: string }, number[], unknown>(
     "septic/fs_readfile",
 );
 
+export const fsReadDir = new RequestType<{ uri: string }, string[], unknown>(
+    "septic/fs_readdir",
+);
+
 export const findYamlFiles = new RequestType<object, string[], unknown>(
     "septic/findYamlFiles",
 );

--- a/packages/extension/server/src/server.ts
+++ b/packages/extension/server/src/server.ts
@@ -18,6 +18,8 @@ import {
     Location,
     DidChangeWatchedFilesNotification,
     CompletionParams,
+    Diagnostic,
+    DiagnosticSeverity,
 } from "vscode-languageserver/node";
 
 import { TextDocument } from "vscode-languageserver-textdocument";
@@ -37,9 +39,12 @@ import {
     SepticMetaInfoProvider,
     SepticCnfg,
     compareCnfgs,
+    scgConfigFromYAML,
+    SepticDiagnosticCode,
 } from "@equinor/septic-config-lib";
 import { getIgnorePatterns, getIgnoredCodes } from "./ignorePath";
 import { ContextManager } from "./contextManager";
+import { findCaseDiscrepancies } from "./util/caseCheck";
 
 // Create a connection for the server, using Node's IPC as a transport.
 // Also include all preview / proposed LSP features.
@@ -97,6 +102,68 @@ async function publishDiagnosticsScgContext(
     });
 
     await Promise.all(diagnosticsPromises);
+
+    await publishCaseDiscrepancyDiagnostics(context);
+}
+
+async function publishCaseDiscrepancyDiagnostics(
+    context: ScgContext,
+): Promise<void> {
+    const yamlUri = context.filePath;
+    const ignorePatterns = await getIgnorePatterns(connection, settingsManager);
+    const codes = getIgnoredCodes(yamlUri, ignorePatterns);
+    if (codes !== undefined && codes.length === 0) {
+        return;
+    }
+
+    const doc = await documentProvider.getDocument(yamlUri);
+    if (!doc) {
+        return;
+    }
+
+    const text = doc.getText();
+    let scgConfig;
+    try {
+        scgConfig = scgConfigFromYAML(text);
+    } catch {
+        return;
+    }
+
+    const templatepath = scgConfig.templatepath;
+    const templateDirUri = yamlUri.startsWith("file:")
+        ? new URL(templatepath + "/", new URL(".", new URL(yamlUri))).href
+        : path.join(path.dirname(yamlUri), templatepath);
+
+    let dirEntries: string[];
+    try {
+        dirEntries = await connection.sendRequest(protocol.fsReadDir, {
+            uri: templateDirUri,
+        });
+    } catch {
+        return;
+    }
+
+    const layoutNames = scgConfig.layout.map((l) => l.name);
+    const discrepancies = findCaseDiscrepancies(layoutNames, dirEntries, text);
+
+    let diagnostics: Diagnostic[] = discrepancies.map((d) => ({
+        severity: DiagnosticSeverity.Warning,
+        range: {
+            start: doc.positionAt(d.offset),
+            end: doc.positionAt(d.offset + d.fileName.length),
+        },
+        message: `Case discrepancy in file path: '${d.fileName}' does not match actual file '${d.actualName}'. This will fail on case-sensitive file systems (Linux).`,
+        code: SepticDiagnosticCode.caseDiscrepancyPath,
+        source: "septic",
+    }));
+
+    if (codes) {
+        diagnostics = diagnostics.filter(
+            (diag) => diag.code && !codes.includes(diag.code as string),
+        );
+    }
+
+    connection.sendDiagnostics({ uri: yamlUri, diagnostics: diagnostics });
 }
 
 async function publishDiagnosticsCnfg(cnfg: SepticCnfg): Promise<void> {

--- a/packages/extension/server/src/test/caseCheck.test.ts
+++ b/packages/extension/server/src/test/caseCheck.test.ts
@@ -1,0 +1,85 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+import { findCaseDiscrepancies, findLayoutNameOffset } from "../util/caseCheck";
+
+describe("Test findLayoutNameOffset", () => {
+    it("Finds offset for simple layout name", () => {
+        const yaml = "layout:\n  - name: template.cnfg\n    source: wells";
+        const offset = findLayoutNameOffset(yaml, "template.cnfg");
+        expect(offset).to.equal(yaml.indexOf("template.cnfg"));
+    });
+
+    it("Finds offset without leading dash", () => {
+        const yaml = "layout:\n  name: myfile.cnfg\n";
+        const offset = findLayoutNameOffset(yaml, "myfile.cnfg");
+        expect(offset).to.equal(yaml.indexOf("myfile.cnfg"));
+    });
+
+    it("Returns -1 when name is not found", () => {
+        const yaml = "layout:\n  - name: other.cnfg\n";
+        const offset = findLayoutNameOffset(yaml, "missing.cnfg");
+        expect(offset).to.equal(-1);
+    });
+
+    it("Handles special regex characters in filename", () => {
+        const yaml = "layout:\n  - name: file(1).cnfg\n";
+        const offset = findLayoutNameOffset(yaml, "file(1).cnfg");
+        expect(offset).to.equal(yaml.indexOf("file(1).cnfg"));
+    });
+
+    it("Finds correct offset with multiple layout entries", () => {
+        const yaml = "layout:\n  - name: first.cnfg\n  - name: second.cnfg\n";
+        const offset = findLayoutNameOffset(yaml, "second.cnfg");
+        expect(offset).to.equal(yaml.indexOf("second.cnfg"));
+    });
+});
+
+describe("Test findCaseDiscrepancies", () => {
+    const yamlText =
+        "layout:\n  - name: Template.cnfg\n  - name: correct.cnfg\n  - name: Other.cnfg\n";
+
+    it("Detects case mismatch between layout name and directory entry", () => {
+        const layoutNames = ["Template.cnfg"];
+        const dirEntries = ["template.cnfg"];
+        const result = findCaseDiscrepancies(layoutNames, dirEntries, yamlText);
+        expect(result).to.have.lengthOf(1);
+        expect(result[0].fileName).to.equal("Template.cnfg");
+        expect(result[0].actualName).to.equal("template.cnfg");
+        expect(result[0].offset).to.equal(yamlText.indexOf("Template.cnfg"));
+    });
+
+    it("Returns empty when casing matches exactly", () => {
+        const layoutNames = ["correct.cnfg"];
+        const dirEntries = ["correct.cnfg"];
+        const result = findCaseDiscrepancies(layoutNames, dirEntries, yamlText);
+        expect(result).to.have.lengthOf(0);
+    });
+
+    it("Returns empty when file does not exist in directory", () => {
+        const layoutNames = ["nonexistent.cnfg"];
+        const dirEntries = ["template.cnfg", "correct.cnfg"];
+        const result = findCaseDiscrepancies(layoutNames, dirEntries, yamlText);
+        expect(result).to.have.lengthOf(0);
+    });
+
+    it("Detects multiple case mismatches", () => {
+        const layoutNames = ["Template.cnfg", "correct.cnfg", "Other.cnfg"];
+        const dirEntries = ["template.cnfg", "correct.cnfg", "other.cnfg"];
+        const result = findCaseDiscrepancies(layoutNames, dirEntries, yamlText);
+        expect(result).to.have.lengthOf(2);
+        expect(result[0].fileName).to.equal("Template.cnfg");
+        expect(result[0].actualName).to.equal("template.cnfg");
+        expect(result[1].fileName).to.equal("Other.cnfg");
+        expect(result[1].actualName).to.equal("other.cnfg");
+    });
+
+    it("Returns empty for empty layout names", () => {
+        const result = findCaseDiscrepancies([], ["file.cnfg"], yamlText);
+        expect(result).to.have.lengthOf(0);
+    });
+
+    it("Returns empty for empty directory entries", () => {
+        const result = findCaseDiscrepancies(["Template.cnfg"], [], yamlText);
+        expect(result).to.have.lengthOf(0);
+    });
+});

--- a/packages/extension/server/src/util/caseCheck.ts
+++ b/packages/extension/server/src/util/caseCheck.ts
@@ -1,0 +1,50 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Equinor ASA
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export interface CaseDiscrepancy {
+    fileName: string;
+    actualName: string;
+    offset: number;
+}
+
+export function findCaseDiscrepancies(
+    layoutNames: string[],
+    dirEntries: string[],
+    yamlText: string,
+): CaseDiscrepancy[] {
+    const discrepancies: CaseDiscrepancy[] = [];
+    for (const fileName of layoutNames) {
+        const actualEntry = dirEntries.find(
+            (entry) => entry.toLowerCase() === fileName.toLowerCase(),
+        );
+        if (actualEntry && actualEntry !== fileName) {
+            const offset = findLayoutNameOffset(yamlText, fileName);
+            if (offset >= 0) {
+                discrepancies.push({
+                    fileName,
+                    actualName: actualEntry,
+                    offset,
+                });
+            }
+        }
+    }
+    return discrepancies;
+}
+
+export function findLayoutNameOffset(text: string, fileName: string): number {
+    const regex = new RegExp(
+        `(?:^|\\n)\\s*-?\\s*name:\\s*${escapeRegExp(fileName)}`,
+        "m",
+    );
+    const match = regex.exec(text);
+    if (match) {
+        return match.index + match[0].indexOf(fileName);
+    }
+    return -1;
+}
+
+function escapeRegExp(str: string): string {
+    return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/packages/septic/src/diagnostics.ts
+++ b/packages/septic/src/diagnostics.ts
@@ -98,6 +98,7 @@ export enum SepticDiagnosticCode {
     invalidReference = "W502",
     unusedEvr = "W503",
     duplicate = "W504",
+    caseDiscrepancyPath = "W701",
     invalidComment = "W601",
 }
 

--- a/packages/septic/src/diagnostics.ts
+++ b/packages/septic/src/diagnostics.ts
@@ -68,6 +68,7 @@ const maxAlgLength = 250;
     4**: Structure
     5**: References
     6**: Comments
+    7**: Files
 */
 export enum SepticDiagnosticCode {
     invalidIdentifier = "W101",
@@ -98,8 +99,8 @@ export enum SepticDiagnosticCode {
     invalidReference = "W502",
     unusedEvr = "W503",
     duplicate = "W504",
-    caseDiscrepancyPath = "W701",
     invalidComment = "W601",
+    caseDiscrepancyPath = "W701",
 }
 
 export enum SepticDiagnosticLevel {


### PR DESCRIPTION
## Summary

Adds diagnostic **W701** (caseDiscrepancyPath) that warns when layout file names in the SCG YAML config have different casing than the actual files on disk.

This helps catch issues that would silently pass on Windows (case-insensitive) but fail on Linux (case-sensitive file systems).

## Changes

- **packages/septic/src/diagnostics.ts** - Added \caseDiscrepancyPath = "W701"\ to \SepticDiagnosticCode\ enum
- **packages/extension/server/src/protocol.ts** - Added \sReadDir\ request type
- **packages/extension/client/src/protocol.ts** - Matching \sReadDir\ request type
- **packages/extension/client/src/requests.ts** - Client handler using \scode.workspace.fs.readDirectory\
- **packages/extension/server/src/util/caseCheck.ts** - Extracted testable utility functions
- **packages/extension/server/src/server.ts** - \publishCaseDiscrepancyDiagnostics()\ integrated into SCG context diagnostics
- **packages/extension/server/src/test/caseCheck.test.ts** - 11 unit tests

## How it works

1. When SCG context diagnostics are published, the YAML file is parsed to get layout names
2. The actual template directory is listed via \sReadDir\
3. Each layout name is compared case-insensitively against the directory entries
4. Mismatches produce a W701 warning at the exact YAML position of the name
5. Users can suppress W701 via septicignore

Closes #944