### PR TITLE
feat: add command to remove default lines from .cnfg files

### DIFF
--- a/packages/extension/client/src/commands.ts
+++ b/packages/extension/client/src/commands.ts
@@ -444,6 +444,49 @@ export function registerCommandGetFunctions(
     });
 }
 
+export function registerCommandRemoveDefaults(
+    context: vscode.ExtensionContext,
+    client: LanguageClient,
+) {
+    vscode.commands.registerCommand("septic.removeDefaults", async () => {
+        const editor = vscode.window.activeTextEditor;
+        if (!editor) {
+            vscode.window.showInformationMessage("No active editor.");
+            return;
+        }
+        if (!editor.document.fileName.endsWith(".cnfg")) {
+            vscode.window.showInformationMessage(
+                "Active file is not a .cnfg file.",
+            );
+            return;
+        }
+        const uri = editor.document.uri.toString();
+        const result = await client.sendRequest(protocol.removeDefaults, {
+            uri,
+        });
+        if (!result) {
+            vscode.window.showInformationMessage(
+                "Unable to process file.",
+            );
+            return;
+        }
+        const currentText = editor.document.getText();
+        if (result === currentText) {
+            vscode.window.showInformationMessage(
+                "No default lines found to remove.",
+            );
+            return;
+        }
+        const fullRange = new vscode.Range(
+            editor.document.positionAt(0),
+            editor.document.positionAt(currentText.length),
+        );
+        const edit = new vscode.WorkspaceEdit();
+        edit.replace(editor.document.uri, fullRange, result);
+        await vscode.workspace.applyEdit(edit);
+    });
+}
+
 export function registerCommands(
     context: vscode.ExtensionContext,
     client: LanguageClient,
@@ -464,4 +507,5 @@ export function registerCommands(
     registerCommandMakeConfig();
     registerCommandPlotModel();
     registerCommandGetFunctions(context, client);
+    registerCommandRemoveDefaults(context, client);
 }

--- a/packages/extension/client/src/protocol.ts
+++ b/packages/extension/client/src/protocol.ts
@@ -109,6 +109,12 @@ export const compareCnfg = new RequestType<
     unknown
 >("septic/compareCnfg");
 
+export const removeDefaults = new RequestType<
+    { uri: string },
+    string,
+    unknown
+>("septic/removeDefaults");
+
 export const contexts = new RequestType<object, string[], unknown>(
     "septic/contexts",
 );

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -50,6 +50,10 @@
         "title": "Septic: Get functions in file"
       },
       {
+        "command": "septic.removeDefaults",
+        "title": "Septic: Remove default lines"
+      },
+      {
         "command": "septic.scgtree.addTemplate",
         "title": "Septic: Insert template below",
         "icon": "$(new-file)"

--- a/packages/extension/server/src/protocol.ts
+++ b/packages/extension/server/src/protocol.ts
@@ -69,6 +69,12 @@ export const compareCnfg = new RequestType<
     unknown
 >("septic/compareCnfg");
 
+export const removeDefaults = new RequestType<
+    { uri: string },
+    string,
+    unknown
+>("septic/removeDefaults");
+
 export const contexts = new RequestType<object, string[], unknown>(
     "septic/contexts",
 );

--- a/packages/extension/server/src/server.ts
+++ b/packages/extension/server/src/server.ts
@@ -37,6 +37,7 @@ import {
     SepticMetaInfoProvider,
     SepticCnfg,
     compareCnfgs,
+    removeDefaultLines,
 } from "@equinor/septic-config-lib";
 import { getIgnorePatterns, getIgnoredCodes } from "./ignorePath";
 import { ContextManager } from "./contextManager";
@@ -178,6 +179,16 @@ connection.onRequest(protocol.compareCnfg, async (param) => {
         return "";
     }
     return compareCnfgs(prevCnfg, currentCnfg, param.settingsFile);
+});
+
+connection.onRequest(protocol.removeDefaults, async (param) => {
+    const cnfg: SepticCnfg | undefined = await langService.cnfgProvider.get(
+        param.uri,
+    );
+    if (!cnfg) {
+        return "";
+    }
+    return removeDefaultLines(cnfg);
 });
 
 connection.onRequest(protocol.contexts, async () => {

--- a/packages/septic/src/index.ts
+++ b/packages/septic/src/index.ts
@@ -29,6 +29,8 @@ export {
     SepticDiagnosticCode,
 } from "./diagnostics";
 export { compareCnfgs } from "./compare";
+export { removeDefaultLines } from "./removeDefaults";
+export type { ObjectDocProvider } from "./removeDefaults";
 export { SepticCnfgFormatter } from "./formatter";
 export {
     SepticConfigProviderFs,

--- a/packages/septic/src/removeDefaults.ts
+++ b/packages/septic/src/removeDefaults.ts
@@ -1,0 +1,125 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Equinor ASA
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { SepticCnfg } from "./cnfg";
+import { SepticAttribute } from "./elements";
+import {
+    SepticMetaInfoProvider,
+    SepticAttributeDocumentation,
+    ISepticObjectDocumentation,
+} from "./metaInfoProvider";
+
+export interface ObjectDocProvider {
+    getObjectDocumentation(
+        objectType: string,
+    ): ISepticObjectDocumentation | undefined;
+}
+
+interface OffsetRange {
+    start: number;
+    end: number;
+}
+
+/**
+ * Returns the text of a cnfg with all attributes set to their default values removed.
+ */
+export function removeDefaultLines(
+    cnfg: SepticCnfg,
+    provider?: ObjectDocProvider,
+): string {
+    const metaInfo = provider ?? SepticMetaInfoProvider.getInstance();
+    const text = cnfg.doc.getText();
+    const rangesToRemove: OffsetRange[] = [];
+
+    for (const obj of cnfg.objects) {
+        const objDoc = metaInfo.getObjectDocumentation(obj.type);
+        if (!objDoc) {
+            continue;
+        }
+        for (const attr of obj.attributes) {
+            const attrDoc = objDoc.getAttribute(attr.key);
+            if (!attrDoc || !attrDoc.default || attrDoc.default.length === 0) {
+                continue;
+            }
+            if (isDefault(attr, attrDoc)) {
+                const range = getAttributeLineRange(text, attr);
+                if (range) {
+                    rangesToRemove.push(range);
+                }
+            }
+        }
+    }
+
+    if (rangesToRemove.length === 0) {
+        return text;
+    }
+
+    // Sort by start offset descending so removals don't shift earlier offsets
+    rangesToRemove.sort((a, b) => b.start - a.start);
+
+    let result = text;
+    for (const range of rangesToRemove) {
+        result = result.slice(0, range.start) + result.slice(range.end);
+    }
+    return result;
+}
+
+function isDefault(
+    attr: SepticAttribute,
+    attrDoc: SepticAttributeDocumentation,
+): boolean {
+    const values = attr.getValues();
+    const defaults: (string | number)[] = attrDoc.default;
+
+    if (values.length !== defaults.length) {
+        return false;
+    }
+
+    for (let i = 0; i < values.length; i++) {
+        if (normalizeValue(values[i]!) !== normalizeValue(defaults[i]!)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+function normalizeValue(value: string | number): string {
+    let str = String(value);
+    // Remove surrounding quotes
+    if (
+        (str.startsWith('"') && str.endsWith('"')) ||
+        (str.startsWith("'") && str.endsWith("'"))
+    ) {
+        str = str.slice(1, -1);
+    }
+    return str.trim();
+}
+
+/**
+ * Returns the full line range (including trailing newline) that contains the attribute.
+ * Expands to cover all lines the attribute spans.
+ */
+function getAttributeLineRange(
+    text: string,
+    attr: SepticAttribute,
+): OffsetRange | undefined {
+    // Find start of line containing attr.start
+    let lineStart = attr.start;
+    while (lineStart > 0 && text[lineStart - 1] !== "\n") {
+        lineStart--;
+    }
+
+    // Find end of line containing attr.end
+    let lineEnd = attr.end;
+    while (lineEnd < text.length && text[lineEnd] !== "\n") {
+        lineEnd++;
+    }
+    // Include the newline character
+    if (lineEnd < text.length && text[lineEnd] === "\n") {
+        lineEnd++;
+    }
+
+    return { start: lineStart, end: lineEnd };
+}

--- a/packages/septic/src/test/removeDefaults.test.ts
+++ b/packages/septic/src/test/removeDefaults.test.ts
@@ -1,0 +1,168 @@
+import { expect } from "chai";
+import { removeDefaultLines, ObjectDocProvider } from "../removeDefaults";
+import {
+    ISepticObjectDocumentation,
+    SepticAttributeDocumentation,
+    SepticObjectDoc,
+} from "../metaInfoProvider";
+import { parseSepticForTest } from "./util";
+
+function makeAttrDoc(
+    name: string,
+    defaults: string[],
+): SepticAttributeDocumentation {
+    return {
+        name,
+        default: defaults,
+        description: "",
+        dataType: "string",
+        enums: [],
+        list: false,
+        tags: [],
+        calc: false,
+        basename: name,
+        noCnfg: false,
+        snippet: "",
+        noSnippet: false,
+    };
+}
+
+function makeObjDoc(
+    name: string,
+    attrs: SepticAttributeDocumentation[],
+): ISepticObjectDocumentation {
+    const attrMap = new Map(attrs.map((a) => [a.name, a]));
+    return {
+        name,
+        attributes: attrs,
+        description: "",
+        parents: [],
+        publicAttributes: [],
+        getAttribute(attr: string) {
+            return attrMap.get(attr);
+        },
+        getObjectDoc(): SepticObjectDoc {
+            return {
+                name,
+                attributes: attrs,
+                description: "",
+                parents: [],
+                publicAttributes: [],
+            };
+        },
+    };
+}
+
+const mockProvider: ObjectDocProvider = {
+    getObjectDocumentation(objectType: string) {
+        if (objectType === "Cvr") {
+            return makeObjDoc("Cvr", [
+                makeAttrDoc("Text1", ['""']),
+                makeAttrDoc("Text2", ['""']),
+                makeAttrDoc("Mode", ["STOPPED"]),
+                makeAttrDoc("Auto", ["OFF"]),
+                makeAttrDoc("PlotMax", ["100"]),
+                makeAttrDoc("PlotMin", ["0"]),
+                makeAttrDoc("Fulf", ["1"]),
+            ]);
+        }
+        return undefined;
+    },
+};
+
+describe("removeDefaultLines", () => {
+    it("should remove attributes set to default values", () => {
+        const text = `  Cvr:           TestCvr
+         Text1=  ""
+         Text2=  ""
+          Mode=  STOPPED
+          Auto=  OFF
+       PlotMax=  100
+       PlotMin=  0
+          Fulf=  5`;
+        const cnfg = parseSepticForTest(text);
+        const result = removeDefaultLines(cnfg, mockProvider);
+        expect(result).to.contain("Fulf=  5");
+        expect(result).to.contain("Cvr:");
+        expect(result).to.not.contain("Mode=");
+        expect(result).to.not.contain("Auto=");
+        expect(result).to.not.contain("PlotMax=");
+        expect(result).to.not.contain("PlotMin=");
+    });
+
+    it("should keep attributes with non-default values", () => {
+        const text = `  Cvr:           TestCvr
+          Mode=  ACTIVE
+          Auto=  ON
+       PlotMax=  200`;
+        const cnfg = parseSepticForTest(text);
+        const result = removeDefaultLines(cnfg, mockProvider);
+        expect(result).to.contain("Mode=  ACTIVE");
+        expect(result).to.contain("Auto=  ON");
+        expect(result).to.contain("PlotMax=  200");
+    });
+
+    it("should return text unchanged when no defaults are present", () => {
+        const text = `  Cvr:           TestCvr
+          Mode=  ACTIVE
+          Fulf=  5`;
+        const cnfg = parseSepticForTest(text);
+        const result = removeDefaultLines(cnfg, mockProvider);
+        expect(result).to.equal(text);
+    });
+
+    it("should handle Text1 and Text2 defaults with quotes", () => {
+        const text = `  Cvr:           TestCvr
+         Text1=  ""
+         Text2=  "Important description"`;
+        const cnfg = parseSepticForTest(text);
+        const result = removeDefaultLines(cnfg, mockProvider);
+        expect(result).to.not.contain("Text1=");
+        expect(result).to.contain('Text2=  "Important description"');
+    });
+
+    it("should handle multiple objects", () => {
+        const text = `  Cvr:           Cvr1
+          Mode=  STOPPED
+          Fulf=  5
+
+  Cvr:           Cvr2
+          Mode=  ACTIVE
+          Auto=  OFF`;
+        const cnfg = parseSepticForTest(text);
+        const result = removeDefaultLines(cnfg, mockProvider);
+        // Cvr1: Mode removed (default), Fulf kept
+        expect(result).to.contain("Fulf=  5");
+        expect(result).to.not.contain("Mode=  STOPPED");
+        // Cvr2: Mode kept (non-default), Auto removed (default)
+        expect(result).to.contain("Mode=  ACTIVE");
+        expect(result).to.not.contain("Auto=  OFF");
+    });
+
+    it("should handle object with no attributes", () => {
+        const text = `  Cvr:           TestCvr`;
+        const cnfg = parseSepticForTest(text);
+        const result = removeDefaultLines(cnfg, mockProvider);
+        expect(result).to.equal(text);
+    });
+
+    it("should handle unknown object types gracefully", () => {
+        const text = `  UnknownType:   Test
+          SomeAttr=  123`;
+        const cnfg = parseSepticForTest(text);
+        const result = removeDefaultLines(cnfg, mockProvider);
+        expect(result).to.equal(text);
+    });
+
+    it("should handle numeric default with different formatting", () => {
+        const text = `  Cvr:           TestCvr
+       PlotMax=  100.0
+       PlotMin=  0`;
+        const cnfg = parseSepticForTest(text);
+        const result = removeDefaultLines(cnfg, mockProvider);
+        // PlotMin=0 matches default '0', should be removed
+        expect(result).to.not.contain("PlotMin=");
+        // PlotMax=100.0 vs default '100' — different string, kept
+        expect(result).to.contain("PlotMax=  100.0");
+    });
+});


### PR DESCRIPTION
## Summary

Adds a new command **"Septic: Remove default lines"** that strips all attribute lines set to their documented default values from the active `.cnfg` file.

This makes configs more compact and easier to read/compare, especially when diffing SCG-generated configs against production saves.

## Usage

1. Open a `.cnfg` file
2. Run `Septic: Remove default lines` from the Command Palette
3. All attributes matching their default values are removed in-place (undoable with Ctrl+Z)

## Implementation

- New `removeDefaultLines()` function in `@equinor/septic-config-lib` that compares each attribute against its documented default from `objectsDoc.yaml`
- Accepts an optional `ObjectDocProvider` parameter for testability
- Handles YAML-parsed numeric defaults and quoted string defaults
- Server handler at `septic/removeDefaults` protocol request
- Client command registered as `septic.removeDefaults`

## Tests

8 unit tests with a mocked `ObjectDocProvider` (independent of actual `objectsDoc.yaml` contents):
- Removes default attributes, keeps non-defaults
- Handles quotes, multiple objects, unknown types, numeric formatting

Closes #320
Closes #934