### PR TITLE
fix: accept direct assignments to non-Evrs in CalcPvr

### DIFF
--- a/packages/septic/src/diagnostics.ts
+++ b/packages/septic/src/diagnostics.ts
@@ -736,7 +736,11 @@ export function validateIdentifier(
         return diagnostics;
     }
 
-    if (obj.isType("FdtaProc") || checkIdentifier(obj.identifier.name)) {
+    if (
+        obj.isType("FdtaProc") ||
+        checkIdentifier(obj.identifier.name) ||
+        (obj.isType("CalcPvr") && checkCalcPvrIdentifier(obj.identifier.name))
+    ) {
         return [];
     }
 
@@ -950,6 +954,10 @@ function validateCalcPvrIdentifierReferences(
         return [];
     }
     const diagnostics: SepticDiagnostic[] = [];
+    const identifierParts = obj.identifier!.name.split(".");
+    const baseName = identifierParts[0]!;
+    const property = identifierParts.length > 1 ? identifierParts[1] : undefined;
+
     if (
         contextProvider.validateReferences(
             obj.identifier!.name,
@@ -969,34 +977,57 @@ function validateCalcPvrIdentifierReferences(
         );
     }
     const referenceToEvr = contextProvider.validateReferences(
-        obj.identifier!.name,
+        baseName,
         hasReferenceToEvr,
     );
     if (referenceToEvr) {
         return diagnostics;
     }
     const referenceToXvr = contextProvider.validateReferences(
-        obj.identifier!.name,
+        baseName,
         defaultRefValidationFunction,
     );
-    const severity = referenceToXvr
-        ? SepticDiagnosticLevel.warning
-        : SepticDiagnosticLevel.hint;
-    const message = referenceToXvr
-        ? `CalcPvr references non Evr ${obj.identifier!.name}`
-        : `No reference to Evr`;
-    const code = referenceToXvr
-        ? SepticDiagnosticCode.invalidReference
-        : SepticDiagnosticCode.missingReference;
+
+    if (referenceToXvr && property) {
+        const metaInfoProvider = SepticMetaInfoProvider.getInstance();
+        const referencedObjects = contextProvider
+            .getObjectsByIdentifier(baseName)
+            .filter((o) => o.isXvr);
+        if (referencedObjects.length) {
+            const publicAttributes =
+                metaInfoProvider.getObjectDocumentation(
+                    referencedObjects[0]!.type,
+                )?.publicAttributes;
+            if (publicAttributes && !publicAttributes.includes(property)) {
+                diagnostics.push(
+                    createDiagnostic(
+                        SepticDiagnosticLevel.error,
+                        {
+                            start: doc.positionAt(obj.identifier!.start),
+                            end: doc.positionAt(obj.identifier!.end),
+                        },
+                        `Unknown public property ${property} for ${referencedObjects[0]!.type}`,
+                        SepticDiagnosticCode.unknownPublicProperty,
+                    ),
+                );
+                return diagnostics;
+            }
+        }
+    }
+
+    if (referenceToXvr) {
+        return diagnostics;
+    }
+
     diagnostics.push(
         createDiagnostic(
-            severity,
+            SepticDiagnosticLevel.hint,
             {
                 start: doc.positionAt(obj.identifier!.start),
                 end: doc.positionAt(obj.identifier!.end),
             },
-            message,
-            code,
+            `No reference to Evr`,
+            SepticDiagnosticCode.missingReference,
         ),
     );
     return diagnostics;
@@ -1333,6 +1364,14 @@ export function checkIdentifier(identifier: string): boolean {
     const invalidChars = containsInvalidChars(filteredIdentifier);
 
     return containsLetter && !invalidChars;
+}
+
+function checkCalcPvrIdentifier(identifier: string): boolean {
+    const parts = identifier.split(".");
+    if (parts.length > 2) {
+        return false;
+    }
+    return parts.every((part) => checkIdentifier(part));
 }
 
 function containsInvalidChars(str: string): boolean {

--- a/packages/septic/src/test/diagnostics.test.ts
+++ b/packages/septic/src/test/diagnostics.test.ts
@@ -1446,6 +1446,63 @@ describe("Test validation of object references", () => {
         );
         expect(diagFilterd.length).to.equal(0);
     });
+    it("Expect no diagnostic for CalcPvr with dotted identifier referencing non-Evr", () => {
+        const text = `
+            Mvr: TestMvr
+
+            CalcPvr: TestMvr.WUpLo
+                Alg= "1"
+		`;
+        const cnfg = parseSepticForTest(text);
+        const objectInfo = metaInfoProvider.getObject("CalcPvr");
+        const diag = validateObjectReferences(
+            cnfg.objects[1]!,
+            cnfg.doc,
+            cnfg,
+            objectInfo!,
+        );
+        const warnings = diag.filter(
+            (d) => d.code === SepticDiagnosticCode.invalidReference,
+        );
+        expect(warnings.length).to.equal(0);
+    });
+    it("Expect error for CalcPvr with dotted identifier and unknown property", () => {
+        const text = `
+            Mvr: TestMvr
+
+            CalcPvr: TestMvr.FakeProperty
+                Alg= "1"
+		`;
+        const cnfg = parseSepticForTest(text);
+        const objectInfo = metaInfoProvider.getObject("CalcPvr");
+        const diag = validateObjectReferences(
+            cnfg.objects[1]!,
+            cnfg.doc,
+            cnfg,
+            objectInfo!,
+        );
+        const errors = diag.filter(
+            (d) => d.code === SepticDiagnosticCode.unknownPublicProperty,
+        );
+        expect(errors.length).to.equal(1);
+    });
+    it("Expect no diagnostics for CalcPvr with dotted identifier referencing Evr", () => {
+        const text = `
+            Evr: TestEvr
+
+            CalcPvr: TestEvr.Meas
+                Alg= "1"
+		`;
+        const cnfg = parseSepticForTest(text);
+        const objectInfo = metaInfoProvider.getObject("CalcPvr");
+        const diag = validateObjectReferences(
+            cnfg.objects[1]!,
+            cnfg.doc,
+            cnfg,
+            objectInfo!,
+        );
+        expect(diag.length).to.equal(0);
+    });
 });
 
 describe("Test validation of object structure", () => {


### PR DESCRIPTION
## Summary

Accepts direct assignments to non-Evr Xvrs (Cvr, Dvr, Mvr, Tvr) in CalcPvr without producing a diagnostic. Previously these generated a W502 warning ("CalcPvr references non Evr").

Also supports dotted CalcPvr identifiers like `CalcPvr: MyMvr.WUpLo` which target a specific public attribute of a non-Evr.

## Changes

- **Allow dotted identifiers in CalcPvr** — `checkCalcPvrIdentifier` validates each part of a dotted name separately (e.g., `35FIC3602B.WUpLo`)
- **Fix reference lookup for dotted identifiers** — splits on `.` and uses the base name for reference resolution
- **Remove W502 diagnostic** for CalcPvr referencing non-Evr Xvrs (these are valid, just not best practice)
- **Keep E208 error** for unknown public properties (e.g., `MyMvr.FakeProperty`)
- **Keep hint** when CalcPvr identifier doesn't resolve to any Xvr at all

## Testing

- Updated existing test to expect no diagnostic for non-Evr references
- Added tests for dotted identifiers (valid property, unknown property, no reference)

Closes #833